### PR TITLE
Adjust Jest test script to allow empty suites

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --ext js,jsx",
-    "test": "jest"
+    "test": "jest --passWithNoTests"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",


### PR DESCRIPTION
## Summary
- update the npm test script so Jest exits successfully when no test files are present

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68da989f9c10832895ef4cf34dd6faa2